### PR TITLE
Rollback to last good configuration state

### DIFF
--- a/lib/ex_control_plane/aggregated_discovery_service_server.ex
+++ b/lib/ex_control_plane/aggregated_discovery_service_server.ex
@@ -45,7 +45,7 @@ defmodule ExControlPlane.AggregatedDiscoveryServiceServer do
         end
       end
 
-    ExControlPlane.Stream.event(stream, node_info, type_url, version)
+    ExControlPlane.Stream.event(stream, node_info, type_url, {version, error})
   end
 
   defp node_info(%DiscoveryRequest{node: %Node{id: node_id, cluster: cluster}}) do


### PR DESCRIPTION
Prior this change the 'sync' state was queried after control plane changes have been pushed via the
`ExControlPlane.ConfigCache.load_events/2` function, and the caller was blocked until all streams were in sync. Of course this only ever worked in the success case. This change fixes this situation by properly returning an error if synchronicity couldn't be reached after a certain amount of time (defaults to 5 seconds). To simplify this situation a simple `GenServer.call` instead of the prior `GenServer.multicall` is used. If an ExControlPlane application is running in a distributed setup where changes must be pushed to other cluster nodes the implementer can wrap the `load_events/2` function in a `:rpc.multicall` or similar.

Leveraging on this the snapshot mechanism was changed to only snapshot what we think was the last good state (the state where we reached synchronicity). Furthermore, it is now possible to do a full rollback to the last good state in case synchronicity hasn't been reached.

Implementation details:
- The error property is forwarded from the GRPC event to the ExControlPlane.Stream event, enabling that the 'sync' state of a stream can be adjusted depending if an error occured during the last config push.
- A separate ETS table was introduced that stores 'candidates' configs. This enables that we can keep the last good state in another table that gets populated by the snapshot mechanism. If synchronicity is reached the 'candidates' values are copied to this table. The Stream processes always read from the 'candidates' table, it's the task of the snapshot mechanism to populate the candidates table with values that are considered 'good'.